### PR TITLE
fix SEC error 403: add user-agent header to EDGAR request to comply w…

### DIFF
--- a/edgar/client.py
+++ b/edgar/client.py
@@ -22,7 +22,7 @@ class EdgarClient():
     instantiate the different endpoints.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, user_agent: str) -> None:
         """Initializes the `EdgarClient`.
 
         ### Usage
@@ -30,7 +30,7 @@ class EdgarClient():
             >>> edgar_client = EdgarClient()
         """
 
-        self.edgar_session = EdgarSession(client=self)
+        self.edgar_session = EdgarSession(client=self, user_agent=user_agent)
 
     def __repr__(self) -> str:
         """String representation of the `EdgarClient` object."""

--- a/edgar/session.py
+++ b/edgar/session.py
@@ -18,7 +18,7 @@ class EdgarSession():
     handles all the requests made to EDGAR.
     """
 
-    def __init__(self, client: object) -> None:
+    def __init__(self, client: object, user_agent: str) -> None:
         """Initializes the `EdgarSession` client.
 
         ### Parameters:
@@ -40,6 +40,7 @@ class EdgarSession():
         self.resource = 'https://www.sec.gov'
         self.api_resource = 'https://data.sec.gov'
         self.total_requests = 0
+        self.user_agent = user_agent
 
         if not pathlib.Path('logs').exists():
             pathlib.Path('logs').mkdir()
@@ -151,6 +152,7 @@ class EdgarSession():
 
         # Define a new request.
         request_request = requests.Request(
+            headers={'user-agent': self.user_agent},
             method=method.upper(),
             url=url,
             params=params,


### PR DESCRIPTION
…ith the "Fair access" guidelines in  https://www.sec.gov/os/accessing-edgar-data:

"The SEC does not allow botnets or automated tools to crawl the site. Any request that has been identified as part of a botnet or an automated tool outside of the acceptable policy will be managed to ensure fair access for all users.

Please declare your user agent in request headers"